### PR TITLE
Bump AWS SDK version, allow for the cert info to be base64 encoded so…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ jspm_packages
 .node_repl_history
 
 .idea
+.DS_Store

--- a/config/default.js
+++ b/config/default.js
@@ -7,7 +7,9 @@ const config = process.env.USE_ENVIRONMENT ?
     "s3-account-bucket": process.env.S3_ACCOUNT_BUCKET,
     "s3-cert-bucket": process.env.S3_CERT_BUCKET,
     "s3-folder": process.env.S3_CERT_FOLDER,
-    "certificate-info": JSON.parse(process.env.S3_CERT_INFO),
+    "certificate-info": JSON.parse(process.env.S3_CERT_INFO_BASE64
+      ? new Buffer(process.env.S3_CERT_INFO, 'base64').toString('ascii')
+      : process.env.S3_CERT_INFO),
     "acme-dns-retry": 30,
     "acme-dns-retry-delay-ms": 2000,
     "acme-account-file": process.env.ACCOUNT_PATH,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Larry Anderson",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.20.0",
+    "aws-sdk": "^2.148.0",
     "es6-promisify": "^4.1.0",
     "node-forge": "^0.6.45",
     "rsa-compat": "^1.2.7",


### PR DESCRIPTION
… we can stick the data in terraform.